### PR TITLE
Implemented copy/paste & fixed doublecallback

### DIFF
--- a/src/model/clipboardManager.ts
+++ b/src/model/clipboardManager.ts
@@ -1,0 +1,24 @@
+// model/clipboardManager.ts
+import { serializeShapes, deserializeShapes } from './core'
+import { Shape } from './tools'
+
+export class ClipboardManager {
+  private clipboard: string | null = null
+
+  copy(shapes: Shape[]) {
+    this.clipboard = serializeShapes(shapes)
+    // Optionally interact with system clipboard
+    navigator.clipboard.writeText(this.clipboard).catch(console.error)
+  }
+
+  paste(): Shape[] | null {
+    if (!this.clipboard) return null
+    return deserializeShapes(this.clipboard)
+  }
+
+  clear() {
+    this.clipboard = null
+  }
+}
+
+export const clipboardManager = new ClipboardManager()

--- a/src/model/core.ts
+++ b/src/model/core.ts
@@ -12,7 +12,7 @@ import {
   filter,
   map,
   ReadonlyOrderedRecord,
-  set,
+  set as setRecord,
   values
 } from './readonlyOrderedRecord'
 import {
@@ -27,8 +27,14 @@ import {
   SelectionToolMode,
   SelectTool,
   Shape,
-  ToolType
+  ToolType,
+  ShapeType
 } from './tools'
+import { nanoid } from 'nanoid'
+
+export function generateId(): string {
+  return nanoid()
+}
 
 export type PersistentState = {
   readonly canvasSize: Size
@@ -253,4 +259,53 @@ export const deleteSelectedShapes = (state: State): State => {
     ...state,
     shapes: filter(state.shapes, shape => !shape.isSelected)
   }
+}
+
+export function serializeShapes(shapes: Shape[]): string {
+  return JSON.stringify(shapes)
+}
+export function deserializeShapes(serialized: string): Shape[] {
+  const parsed = JSON.parse(serialized)
+  return parsed.map((shape: any) => {
+    // Ensure each shape has a valid ID
+    const id = shape.id || generateId()
+
+    // Validate shape type
+    const type: ShapeType =
+      shape.type === RectangleShape || shape.type === EllipseShape
+        ? shape.type
+        : RectangleShape // Default to rectangle if type is invalid
+
+    // Reconstruct the shape with validated properties
+    return {
+      id,
+      type,
+      x: Number(shape.x) || 0,
+      y: Number(shape.y) || 0,
+      width: Number(shape.width) || 0,
+      height: Number(shape.height) || 0,
+      color: shape.color || '#ffffff',
+      borderColor: shape.borderColor || '#000000',
+      isSelected: Boolean(shape.isSelected)
+    }
+  })
+}
+export function copyShapes(shapes: Shape[]): string {
+  return serializeShapes(shapes)
+}
+export function pasteShapes(
+  serializedShapes: string,
+  existingShapes: ReadonlyOrderedRecord<Shape>
+): ReadonlyOrderedRecord<Shape> {
+  const newShapes = deserializeShapes(serializedShapes)
+  return newShapes.reduce((shapes, shape) => {
+    const newShape = {
+      ...shape,
+      id: generateId(),
+      x: shape.x + 10,
+      y: shape.y + 10,
+      isSelected: true
+    }
+    return setRecord(shapes, newShape.id, newShape)
+  }, existingShapes)
 }

--- a/src/model/core.ts
+++ b/src/model/core.ts
@@ -244,7 +244,7 @@ export const getSelectedShapes = (state: State): Shape[] => {
 }
 
 export const updateShape = (state: State, shape: Shape): State => {
-  return { ...state, shapes: set(state.shapes, shape.id, shape) }
+  return { ...state, shapes: setRecord(state.shapes, shape.id, shape) }
 }
 
 export const setSnapToGridSetting = (
@@ -293,17 +293,17 @@ export function deserializeShapes(serialized: string): Shape[] {
 export function copyShapes(shapes: Shape[]): string {
   return serializeShapes(shapes)
 }
+
 export function pasteShapes(
-  serializedShapes: string,
+  shapesToPaste: Shape[],
   existingShapes: ReadonlyOrderedRecord<Shape>
 ): {
   updatedShapes: ReadonlyOrderedRecord<Shape>
   newShapeIds: string[]
 } {
-  const newShapes = deserializeShapes(serializedShapes)
   const newShapeIds: string[] = []
 
-  const updatedShapes = newShapes.reduce((shapes, shape) => {
+  const updatedShapes = shapesToPaste.reduce((shapes, shape) => {
     const newId = generateId()
     newShapeIds.push(newId)
     const newShape = {

--- a/src/model/core.ts
+++ b/src/model/core.ts
@@ -296,16 +296,43 @@ export function copyShapes(shapes: Shape[]): string {
 export function pasteShapes(
   serializedShapes: string,
   existingShapes: ReadonlyOrderedRecord<Shape>
-): ReadonlyOrderedRecord<Shape> {
+): {
+  updatedShapes: ReadonlyOrderedRecord<Shape>
+  newShapeIds: string[]
+} {
   const newShapes = deserializeShapes(serializedShapes)
-  return newShapes.reduce((shapes, shape) => {
+  const newShapeIds: string[] = []
+
+  const updatedShapes = newShapes.reduce((shapes, shape) => {
+    const newId = generateId()
+    newShapeIds.push(newId)
     const newShape = {
       ...shape,
-      id: generateId(),
+      id: newId,
       x: shape.x + 10,
       y: shape.y + 10,
-      isSelected: true
+      isSelected: false // We'll handle selection separately
     }
     return setRecord(shapes, newShape.id, newShape)
   }, existingShapes)
+
+  return { updatedShapes, newShapeIds }
+}
+export function selectShapes(
+  shapes: ReadonlyOrderedRecord<Shape>,
+  shapeIds: string[]
+): ReadonlyOrderedRecord<Shape> {
+  return shapeIds.reduce((updatedShapes, id) => {
+    const shape = updatedShapes.data[id]
+    if (shape) {
+      return setRecord(updatedShapes, id, { ...shape, isSelected: true })
+    }
+    return updatedShapes
+  }, shapes)
+}
+
+export function deselectAllShapes(
+  shapes: ReadonlyOrderedRecord<Shape>
+): ReadonlyOrderedRecord<Shape> {
+  return map(shapes, shape => ({ ...shape, isSelected: false }))
 }

--- a/src/shell/istore.ts
+++ b/src/shell/istore.ts
@@ -4,9 +4,17 @@ import { History } from '@/model/history'
 import { SelectionToolMode, ToolType } from '@/model/tools'
 import type { Shape } from '@/model/tools'
 
+// Define a type for clipboard content
+export type ClipboardContent = {
+  serializedShapes: string
+}
 export interface IStore {
   // History State
   history: History
+  // New clipboard-related properties and methods
+  clipboard: ClipboardContent | null
+  copySelectedShapes: () => void
+  pasteShapes: () => void
 
   // Computed selectors
   getCanvasBorderSize: () => Size

--- a/src/shell/store.ts
+++ b/src/shell/store.ts
@@ -1,3 +1,5 @@
+import { createCopyAction, createPasteAction } from '@/model/actions'
+import { clipboardManager } from '@/model/clipboardManager'
 import * as core from '@/model/core'
 import { Point, Size } from '@/model/geometry'
 import {
@@ -16,6 +18,30 @@ const initialState = core.initialState
 export const useStore = create<IStore>()((set, get) => ({
   // History State
   history: createInitialHistory(initialState),
+  clipboard: null,
+  copySelectedShapes: () => {
+    const selectedShapes = get().getSelectedShapes()
+    const serializedShapes = core.serializeShapes(selectedShapes)
+    set({ clipboard: { serializedShapes } })
+  },
+  pasteShapes: () => {
+    const { clipboard, history } = get()
+    if (clipboard) {
+      set(state => {
+        const updatedShapes = core.pasteShapes(
+          clipboard.serializedShapes,
+          state.history.present.shapes
+        )
+        const newPresent = {
+          ...state.history.present,
+          shapes: updatedShapes
+        }
+        return {
+          history: addToHistory(state.history, newPresent)
+        }
+      })
+    }
+  },
 
   // Computed selectors
   getCanvasBorderSize: () => core.getBorderSize(get().history.present),

--- a/src/shell/store.ts
+++ b/src/shell/store.ts
@@ -21,13 +21,12 @@ export const useStore = create<IStore>()((set, get) => ({
   copySelectedShapes: () => {
     const selectedShapes = get().getSelectedShapes()
     if (selectedShapes.length > 0) {
-      const serializedShapes = core.serializeShapes(selectedShapes)
+      clipboardManager.copy(selectedShapes)
       set(state => {
         const deselectedShapes = core.deselectAllShapes(
           state.history.present.shapes
         )
         return {
-          clipboard: { serializedShapes },
           history: addToHistory(state.history, {
             ...state.history.present,
             shapes: deselectedShapes
@@ -38,17 +37,17 @@ export const useStore = create<IStore>()((set, get) => ({
   },
 
   pasteShapes: () => {
-    const { clipboard, history } = get()
-    if (clipboard) {
+    const pastedShapes = clipboardManager.paste()
+    if (pastedShapes) {
       set(state => {
         const { updatedShapes, newShapeIds } = core.pasteShapes(
-          clipboard.serializedShapes,
+          pastedShapes,
           state.history.present.shapes
         )
 
-        // Deselect all shapes and then select only the newly pasted shapes
+        // Select only the newly pasted shapes
         const shapesWithSelection = core.selectShapes(
-          core.deselectAllShapes(updatedShapes),
+          updatedShapes,
           newShapeIds
         )
 

--- a/src/view/component/Canvas.tsx
+++ b/src/view/component/Canvas.tsx
@@ -1,3 +1,4 @@
+import { useCopyPaste } from '../hooks/useCopyPaste'
 import useGlobalHotkey from '../hooks/useGlobalHotkey'
 import useRelativeMouseDown from '../hooks/useRelativeMouseDown'
 import useRelativeMouseMove from '../hooks/useRelativeMouseMove'
@@ -10,6 +11,8 @@ import { useRef } from 'react'
 
 const Canvas = () => {
   const canvasRef = useRef(null)
+
+  const { handleCopy, handlePaste } = useCopyPaste()
 
   const { width, height } = useStore(state => state.history.present.canvasSize)
   const shapeIds = useStore().getShapeIds()
@@ -31,6 +34,9 @@ const Canvas = () => {
   useGlobalHotkey({ key: 'Delete' }, () => {
     deleteSelectedShapes()
   })
+
+  useGlobalHotkey({ key: 'c', ctrl: true }, handleCopy)
+  useGlobalHotkey({ key: 'v', ctrl: true }, handlePaste)
 
   return (
     <svg

--- a/src/view/hooks/useCopyPaste.ts
+++ b/src/view/hooks/useCopyPaste.ts
@@ -1,0 +1,22 @@
+// lib/useCopyPaste.ts
+import useGlobalHotkey from './useGlobalHotkey'
+import { useStore } from '@/shell/store'
+import { useCallback } from 'react'
+
+export function useCopyPaste() {
+  const { copySelectedShapes, pasteShapes } = useStore()
+
+  const handleCopy = useCallback(() => {
+    copySelectedShapes()
+  }, [copySelectedShapes])
+
+  const handlePaste = useCallback(() => {
+    pasteShapes()
+  }, [pasteShapes])
+
+  // Set up hotkeys
+  useGlobalHotkey({ key: 'c', ctrl: true }, handleCopy)
+  useGlobalHotkey({ key: 'v', ctrl: true }, handlePaste)
+
+  return { handleCopy, handlePaste }
+}


### PR DESCRIPTION
CTRL + C - copy
CTRL + V - paste

Regarding bug fix:
- Added a global `Map` to track registered hotkeys by their key combination string to prevent multiple listeners being added for the same hotkey.
- Refactored `useGlobalHotkey` to use `useEffect` for proper event listener management, ensuring that listeners are registered and cleaned up correctly in compliance with React's rules of hooks.
- Removed conditional hook calls that caused warnings and potential bugs, ensuring `useEventListener` is consistently managed within `useEffect`.
- Included cleanup logic to remove old listeners if a hotkey is re-registered, preventing potential memory leaks and unwanted behavior.